### PR TITLE
Set babel env to production in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node devServer.js",
     "build": "npm run clean && npm run build:lib && npm run build:umd && npm run build:examples",
-    "build:lib": "node_modules/.bin/babel src --out-dir lib",
+    "build:lib": "BABEL_ENV=production node_modules/.bin/babel src --out-dir lib",
     "build:umd": "NODE_ENV=production webpack --config webpack.config.prod.js",
     "build:examples": "NODE_ENV=production webpack --config examples/webpack.config.examples.js",
     "clean": "rimraf dist && rimraf lib && npm run clean:examples",


### PR DESCRIPTION
Still includes and depends on dev deps like `react-transform-hmr` when installed from npm. See:

```
npm install react-kronos
cd node_modules/react-kronos
grep -r "hmr" lib
lib/calendar.js:var _reactTransformHmr2 = require('react-transform-hmr');
lib/cell.js:var _reactTransformHmr2 = require('react-transform-hmr');
lib/index.js:var _reactTransformHmr2 = require('react-transform-hmr');
lib/nav.js:var _reactTransformHmr2 = require('react-transform-hmr');
lib/styled-component.js:var _reactTransformHmr2 = require('react-transform-hmr');
```
