### PR TITLE
Add visible prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A fast, intuitive, and elegant date and time picker for React.
 - `returnAs` - *string* : onChange format `JS_DATE`, `MOMENT`, `ISO`, `STRING` (default: same as input)
 - `min` - *Date()*, *Moment()*, *ISO* to set as the minimum datetime
 - `max` - *Date()*, *Moment()*, *ISO* to set as the maximum datetime
+- `visible` - *boolean* : opens/closes the dropdown when true/false
 - `closeOnSelect` - *boolean* : closes the dropdown when a value is selected (default: `true`)
 - `closeOnBlur` - *boolean* : closes the dropdown when the field is blurred (default: `true`)
 - `shouldTriggerOnChangeForDateTimeOutsideRange` - *boolean*: optionally allow dates outside min/max range to trigger onChanges (default: `false`)

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ class Kronos extends Component {
       Types.MOMENT,
       Types.STRING,
     ]),
+    visible: PropTypes.bool,
     closeOnSelect: PropTypes.bool,
     closeOnBlur: PropTypes.bool,
     placeholder: PropTypes.string,
@@ -55,6 +56,7 @@ class Kronos extends Component {
   }
 
   static defaultProps = {
+    visible: false,
     closeOnSelect: true,
     closeOnBlur: true,
     shouldTriggerOnChangeForDateTimeOutsideRange: false,
@@ -63,13 +65,21 @@ class Kronos extends Component {
 
   static above = false
 
+  componentWillMount() {
+    if ('visible' in this.props) {
+      this.setState({ visible: this.props.visible });
+    }
+  }
+
   componentWillReceiveProps(nextProps) {
     if (this.props != nextProps) {
       this.validate(this.getDateTimeInput(nextProps).datetime, null, true)
-      this.setState({
-        datetime: this.getDateTimeInput(nextProps).datetime,
-        input: this.getDateTimeInput(nextProps).input,
-      })
+      this.setState(Object.assign({
+          datetime: this.getDateTimeInput(nextProps).datetime,
+          input: this.getDateTimeInput(nextProps).input,
+        },
+        ('visible' in nextProps) ? { visible: nextProps.visible } : {}
+      ))
     }
   }
 


### PR DESCRIPTION
This adds a `visible` prop to the Kronos component which allows a parent component to control the dropdown visibility.

In my use case, we need this property to initialize the Kronos component in an open state.

To test this, render the component like below in `examples/app.js`. The calendar should be in an open state.

```
<Kronos
  ref='datetime'
  date={this.state.datetime}
  onChange={::this.onChange}
  min={minDate}
  max={maxDate}
  visible={ true }
  placeholder={'This is the placeholder'}
  {...props}
/>
```

Thanks for reviewing this!
