### PR TITLE
Hide times that don't validate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 lib
 dist
+.idea

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A fast, intuitive, and elegant date and time picker for React.
 - `closeOnBlur` - *boolean* : closes the dropdown when the field is blurred (default: `true`)
 - `shouldTriggerOnChangeForDateTimeOutsideRange` - *boolean*: optionally allow dates outside min/max range to trigger onChanges (default: `false`)
 - `preventClickOnDateTimeOutsideRange` - *boolean*: optionally prevent users from clicking on dates outside min/max range (default: `false`)
+- `hideOutsideDateTimes` - *boolean*: optionally hide times that do not pass validation
 - `placeholder` - *string* : placeholder text when there is no value
 - `name` - *string* : name used for the input form
 - `options:`

--- a/examples/app.js
+++ b/examples/app.js
@@ -193,34 +193,6 @@ export default class App extends Component {
                 {...props}
               />
             </div>
-            <h2>Hide Outside Date Times</h2>
-            <div className='kronos'>
-              <button className='toggle-button' onClick={::this.onClickButtonUncontrolled}>
-                Toggle Visibility
-              </button>
-              <Kronos
-                ref='uncontrolled'
-                date={this.state.uncontrolledDatetime}
-                onChangeDateTime={::this.onChangeUncontrolled}
-                min={minDate}
-                max={maxDate}
-                placeholder={'This is the placeholder'}
-                hideOutsideDateTimes
-                {...props}
-              />
-              <Kronos
-                time={this.state.uncontrolledDatetime}
-                format={'H:mm'}
-                onChangeDateTime={::this.onChangeUncontrolled}
-                min={minDate}
-                minTime={minTime}
-                max={maxDate}
-                maxTime={maxTime}
-                placeholder={'Another one'}
-                hideOutsideDateTimes
-                {...props}
-              />
-            </div>
           </main>
         </div>
       </div>

--- a/examples/app.js
+++ b/examples/app.js
@@ -193,6 +193,33 @@ export default class App extends Component {
                 {...props}
               />
             </div>
+            <h2>Hide Outside Date Times</h2>
+            <div className='kronos'>
+              <button className='toggle-button' onClick={::this.onClickButtonUncontrolled}>
+                Toggle Visibility
+              </button>
+              <Kronos
+                ref='uncontrolled'
+                date={this.state.uncontrolledDatetime}
+                onChangeDateTime={::this.onChangeUncontrolled}
+                min={minDate}
+                max={maxDate}
+                placeholder={'This is the placeholder'}
+                {...props}
+              />
+              <Kronos
+                time={this.state.uncontrolledDatetime}
+                format={'H:mm'}
+                onChangeDateTime={::this.onChangeUncontrolled}
+                min={minDate}
+                minTime={minTime}
+                max={maxDate}
+                maxTime={maxTime}
+                placeholder={'Another one'}
+                hideOutsideDateTimes
+                {...props}
+              />
+            </div>
           </main>
         </div>
       </div>

--- a/examples/app.js
+++ b/examples/app.js
@@ -205,6 +205,7 @@ export default class App extends Component {
                 min={minDate}
                 max={maxDate}
                 placeholder={'This is the placeholder'}
+                hideOutsideDateTimes
                 {...props}
               />
               <Kronos

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -275,8 +275,8 @@ class Calendar extends Component {
                   type = 'base'
                   break
               }
-              
-              if (hideOutsideDateTimes && !this.props.validate(cell.moment, level)) {
+
+              if (level === 'hours' && hideOutsideDateTimes && !this.props.validate(cell.moment, level)) {
                 return null
               }
 

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -236,7 +236,7 @@ class Calendar extends Component {
   }
 
   render() {
-    const { level, datetime, classes, inputRect } = this.props
+    const { level, datetime, classes, inputRect, hideOutsideDateTimes } = this.props
 
     let calendarClass = classes.calendarBelow
 
@@ -275,6 +275,11 @@ class Calendar extends Component {
                   type = 'base'
                   break
               }
+              
+              if (hideOutsideDateTimes && !this.props.validate(cell.moment, level)) {
+                return null
+              }
+
               return (
                 <Cell
                   key={i}
@@ -290,7 +295,7 @@ class Calendar extends Component {
                   invalid={this.props.validate(cell.moment, level)}
                 />
               )
-            })
+            }).filter( cell => cell != null )
           }
           { level != 'hours' &&
             <div className={classes.today} onClick={::this.onToday}>

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ class Kronos extends Component {
     placeholder: PropTypes.string,
     name: PropTypes.string,
     options: PropTypes.object,
+    hideOutsideDateTimes: PropTypes.bool,
     // Advanced controls
     controlVisibility: PropTypes.bool,
     visible: PropTypes.bool,
@@ -414,6 +415,7 @@ class Kronos extends Component {
             validate={::this.validate}
             options={this.props.options}
             inputRect={this._input.getClientRects()[0]}
+            hideOutsideDateTimes={this.props.hideOutsideDateTimes}
           />
         }
       </div>


### PR DESCRIPTION
Adds the `hideOutsideDateTimes` prop, to hide times (and only times - doesn't make sense with dates) that do not pass validation

I've got a use case for not displaying times that don't validate in the time selector (Basically a limit on the times that are displayed, just displaying them as invalid/unselectable isn't quite enough) & couldn't find a prop for it in the docs.

If this is already a feature, I can maybe change this PR to a docs update that makes it easier to find.

Also input on the prop naming is likely needed, others seemed to refer to invalid times as "outside range" instead of invalid, so I went with that

**Current:**
![selection_114](https://cloud.githubusercontent.com/assets/2522620/18869808/dc763894-84a5-11e6-9538-2f28bb72c5ae.png)

**With hideOutsideDateTimes:**
![selection_115](https://cloud.githubusercontent.com/assets/2522620/18869823/e8ca54c2-84a5-11e6-9b9d-06bcc4439a5d.png)
