### PR TITLE
Fixed day label cells generation on calendar header

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -179,13 +179,16 @@ class Calendar extends Component {
       case 'days': {
         const start = datetime.clone().startOf('month').weekday(0)
         const end = datetime.clone().endOf('month').weekday(6)
+        const header_start = start.clone()
+        const header_end = header_start.clone().weekday(6)
         let days = []
         const format = get(this.props, 'options.format.day') || 'D'
 
-        Moment.weekdaysMin()
-          .forEach(day => {
+        Moment()
+          .range(header_start, header_end)
+          .by(Units.DAY, day => {
             days.push({
-              label: day,
+              label: day.format('dd'),
               header: true,
             })
           })

--- a/src/styles.js
+++ b/src/styles.js
@@ -20,7 +20,7 @@ function initializeMoment(options) {
     else {
       Moment.updateLocale('en', {
         week: { dow: 1 },
-        weekdaysMin: ['M', 'T', 'W', 'T', 'F', 'S', 'S'],
+        weekdaysMin: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
       })
     }
   }


### PR DESCRIPTION
Day labels in calendar header now respect moment dow locale setting.
Updated default moment settings accordingly, `weekdaysMin` array should always start with Sunday.

---

You can test the wrong behavior using a locale different than "en" with a `dow` setting different than "0".
Below is an attached screenshot using Italian locale for reference:
![image](https://cloud.githubusercontent.com/assets/2650264/24757391/65fbf20a-1adf-11e7-8434-bc28bdfe090b.png)
You can notice that 06/04/2017 is wrongly reported as Wednesday ("me") instead of Thursday ("gi").